### PR TITLE
State management in scoreboard and gameplay

### DIFF
--- a/COMBO/Assets/Prefabs/ScoreBoard.prefab
+++ b/COMBO/Assets/Prefabs/ScoreBoard.prefab
@@ -685,9 +685,10 @@ MonoBehaviour:
   resultsScreen: {fileID: 2722700073437338448}
   gameplayScreen: {fileID: 5795211973040729934}
   infoScreen: {fileID: 2945886987922454428}
-  life1: {fileID: 6709802502640145129}
-  life2: {fileID: 3967688241622590374}
-  life3: {fileID: 8078300378847015411}
+  lifeImages:
+  - {fileID: 8078300378847015411}
+  - {fileID: 3967688241622590374}
+  - {fileID: 6709802502640145129}
   ratingImages:
   - {fileID: 5729410109615835511}
   - {fileID: 4795456944185662106}
@@ -3446,7 +3447,7 @@ RectTransform:
   m_GameObject: {fileID: 6106109082904505538}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.74999994, y: 0.74999994, z: 0.74999994}
+  m_LocalScale: {x: 0.7499999, y: 0.7499999, z: 0.7499999}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 3742736505011137306}
@@ -3454,7 +3455,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: 15}
+  m_AnchoredPosition: {x: -80, y: 14.9999695}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2628585202684038433

--- a/COMBO/Assets/Scripts/EnvironmentManager.cs
+++ b/COMBO/Assets/Scripts/EnvironmentManager.cs
@@ -36,7 +36,6 @@ public class EnvironmentManager : MonoBehaviour
                 light.intensity = standardIntensity;
             }
         }
-        ZoomAwayFromScoreboard();
     }
 
     // Update is called once per frame

--- a/COMBO/Assets/Scripts/InteractableManager.cs
+++ b/COMBO/Assets/Scripts/InteractableManager.cs
@@ -91,7 +91,7 @@ public class InteractableManager : MonoBehaviour
             // Debug.Log("pressStartTime: " + pressStartTime);
             // Debug.Log("pressHoldTime: " + pressHoldTime);
             // Debug.Log("Time: " + Time.time);
-            if(Input.GetKeyDown(trigger)) //when the key is first pressed
+            if (Input.GetKeyDown(trigger)) //when the key is first pressed
             {
                 pressStartTime = Time.time;
                 //Debug.Log("Starting Timer");
@@ -105,8 +105,9 @@ public class InteractableManager : MonoBehaviour
             {
                 if (pressStartTime + pressHoldTime <= Time.time)
                 {
-                    deactivateButton(true); // successfully performed operation
-                    //Debug.Log("Action Complete!");
+                    deactivateButton(); // successfully performed operation
+                    manager.updateScore();
+                    Debug.Log("Good job");
                     LeanTween.cancel(bar);
                     hideTimerBar();
                     resetTimerBar();
@@ -119,7 +120,7 @@ public class InteractableManager : MonoBehaviour
                 }
                 holdingButton = true;
             }
-            else if(Input.GetKeyUp(trigger))
+            else if (Input.GetKeyUp(trigger))
             {
                 pressStartTime = 0;
                 holdingButton = false;
@@ -128,10 +129,12 @@ public class InteractableManager : MonoBehaviour
             }
         }
 
-        if(buttonIsActive && (startTime + time <= Time.time && buttonIsActive) && !holdingButton)
+        if (buttonIsActive && (startTime + time <= Time.time && buttonIsActive) && !holdingButton)
         {
             //Debug.Log("ouch, didn't make it");
-            deactivateButton(false);
+            deactivateButton();
+            manager.missedAlert();
+            Debug.Log("You suck ");
         }
     }
 
@@ -140,7 +143,7 @@ public class InteractableManager : MonoBehaviour
         manager.colorTimerBar(new Color32(48, 123, 140, 255));
         manager.showTimerBar();
         manager.animateTimerBar(pressHoldTime);
-        
+
     }
 
     void stopPlayerTimerBar()
@@ -200,7 +203,7 @@ public class InteractableManager : MonoBehaviour
 
     void showTimerBar()
     {
-        LeanTween.scale(TimerBar, TimerBarScale, .5f).setEase( LeanTweenType.easeOutBack);
+        LeanTween.scale(TimerBar, TimerBarScale, .5f).setEase(LeanTweenType.easeOutBack);
     }
 
     void resetTimerBar()
@@ -214,7 +217,7 @@ public class InteractableManager : MonoBehaviour
     public void activateButton()
     {
         buttonIsActive = true;
-        if(playerInRange)
+        if (playerInRange)
         {
             instructionBubble.showBubble();
         }
@@ -227,30 +230,19 @@ public class InteractableManager : MonoBehaviour
         startTime = Time.time;
     }
 
-    public void deactivateButton(bool completed)
+    public void deactivateButton()
     {
         buttonIsActive = false;
-        // hideTimerBar();
         alertBubble.hideBubble();
         instructionBubble.hideBubble();
-        
-        if(completed)
-        {
-            manager.updateScore();
-            Debug.Log("Good job");
-        }
-        else
-        {
-            manager.missedAlert();
-            Debug.Log("You suck ");
-        }
+        hideTimerBar();
     }
 
     void resetAnimation()
     {
         LeanTween.moveY(interactable, interactable.transform.position.y, 0.5f).setOnComplete(() =>
         {
-        anim.SetInteger("InteractionBehavior", ((int)Interaction.IDLE));
+            anim.SetInteger("InteractionBehavior", ((int)Interaction.IDLE));
         });
     }
 


### PR DESCRIPTION
## State Management in Gameplay
* GameController now keeps track of current state (info. gameplay, or results) and knows how to transition between them (`NextState` method)
* Update loop differentiates between states

## Scoreboard
* Score board tracks it's current state and can easily replace the contents
* Life Images are now an array, paving the path for extra lives

## Interactibles
* `deactivateButton` doesn't call the gameManager now, those calls happen next to it (since game over states and other call `deactivateButton`, we were getting into some weird states)
* `deactivateButton` hides the timer bars

## Environment Manager
* no longer zoomz out on `Start`. The GameManager now calls `ZoomToScoreboard` on `Start` for the info screen
